### PR TITLE
fix benchmark result posting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,13 +1,17 @@
 name: Benchmark
 on:
   - pull_request
-permissions:
-  pull-requests: write    # needed to post comments
+
+# No special permissions needed — the action uploads an artifact
+# instead of commenting directly. A separate workflow_run workflow
+# (post_benchmark_comment.yml) picks up the artifact and posts the comment.
+
 jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+      - uses: hakkelt/AirspeedVelocity.jl@master
         with:
           julia-version: '1'
+          post-comment: 'false'

--- a/.github/workflows/post_benchmark_comment.yml
+++ b/.github/workflows/post_benchmark_comment.yml
@@ -1,0 +1,19 @@
+name: Post Benchmark Comment
+
+on:
+  workflow_run:
+    workflows: ["Benchmark"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hakkelt/AirspeedVelocity.jl/post-comment@master
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
In this PR, I try to fix this problem by dividing the benchmarking into two phases:
1. Run the benchmark, save the results to a file, and upload it as an artifact. -> It does not need any special permissions.
2. Download the artifact and post the content as a comment. -> This gets triggered by the first phase via "workflow_run", and my hope is that it is possible to selectively set write permission to this job only.